### PR TITLE
Fixing readme VCS pipx install link

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ $ pipx install tele-forge
 ### **From VCS**
 
 ```shell
-$ pipx install git+ssh://git@github.com:TeleTrackingTechnologies/forge.git
+$ pipx install git+https://git@github.com/TeleTrackingTechnologies/forge
 ```
 
 ### **From Source (after cloning)**


### PR DESCRIPTION
### Fixes readme link for installing to `pipx` from github
Made a mistake and left in ssh link instead of https