### PR TITLE
Correcting subprocess call to avoid unicode errors

### DIFF
--- a/forge/cli.py
+++ b/forge/cli.py
@@ -1,7 +1,7 @@
 """ Forge CLI """
 
 from typing import List
-from subprocess import PIPE, Popen
+from subprocess import Popen
 import sys
 import click
 
@@ -100,7 +100,7 @@ def list_forge_plugins() -> None:
 
 def run_forge_plugin(command: List[str]) -> None:
     """ Forge Plugin """
-    process = Popen(command, stdout=PIPE, stderr=PIPE)
+    process = Popen(command)
 
     stdout, stderr = process.communicate()
     if stdout:


### PR DESCRIPTION
## Corrects `subprocess` call when using `forge plugin-name`
- Removed redirection of `stdout` and `stderr` to PIPE
    - Enables live output from the `subprocess` call
    - Avoids Unicode characters and terminal progress bar issues being saved in a buffer