### PR TITLE
Forge 2.0.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ init:
 	( \
     . .venv/bin/activate; \
     pip3 install -r requirements.txt; \
+    pip3 install -e .; \
     )
 
 dev: init

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ $ python3 -m pipx ensurepath
 
 > **Are you a ZSH User?** Zsh doesn't source `~/.profile`, use `~/.zprofile` instead
 
-> **IMPORTANT:** Now reboot/logout to gain access to `pipx`
+> **IMPORTANT:** Now reboot/logout to gain access to `pipx` globally
 
 ### **Windows**
 
@@ -46,11 +46,15 @@ setx /m PIPX_BIN_DIR "~/.forge/bin"
 python -m pipx ensurepath --force
 ```
 
-> **IMPORTANT:** Now reboot/logout to gain access to `pipx`
+> **IMPORTANT:** Now reboot/logout to gain access to `pipx` globally
 
 ---
 
 ## Installation
+
+> **NOTE:** Befrore moving on make sure the envirnonment variables are set, open a new terminal and run
+
+> `echo $PIPX_HOME` or `$env:PIPX_HOME`
 
 ### **Via PyPI**
 
@@ -137,3 +141,15 @@ To revert back to the mainstream branch you will need to uninstall your local pl
 `pipx uninstall .`
 
 Then follow the above section's install instructions. (`pipx install tele-forge`)
+
+---
+
+## Migrating from Forge 1.0?
+
+We need to get rid of some things before trying to install Forge 2.0+
+
+1. `pip uninstall tele-forge`
+2. See the Post Install step above for the where/which commands
+3. Delete the forge binary from step 2
+4. Re run the where/which commands and ensure forge doesn't exist on your PATH
+5. You're ready to install Forge 2.0+ using the above installation guide!

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ $ echo 'export PIPX_BIN_DIR="$HOME/.forge/bin"' >> ~/.profile
 $ python3 -m pipx ensurepath
 ```
 
+> **Are you a ZSH User?** Zsh doesn't source `~/.profile`, use `~/.zprofile` instead
+
 > **IMPORTANT:** Now reboot/logout to gain access to `pipx`
 
 ### **Windows**
@@ -39,8 +41,8 @@ In PowerShell, running as administartor, run the following:
 
 ```shell
 python -m pip install --user pipx
-$env:PIPX_HOME="~/.forge"
-$env:PIPX_BIN_DIR="~/.forge/bin"
+setx /m PIPX_HOME "~/.forge"
+setx /m PIPX_BIN_DIR "~/.forge/bin"
 python -m pipx ensurepath --force
 ```
 
@@ -78,17 +80,27 @@ To verify your installation was successful
 
 ```shell
 $ which forge
+#/home/USERNAME/.forge/bin/forge
 # OR
 where.exe forge
+#C:\Users\USERNAME\.forge\bin\forge.exe
 ```
 
-should return the installed location of forge, then:
+Then, to see the help interface:
 
 ```
 $ forge -h
 ```
 
-should return the simple help interface.
+---
+
+## Adding plugins
+
+```
+forge add -s SOURCE
+forge add -s git+ssh://git@REPO_LINK
+...
+```
 
 ---
 
@@ -97,3 +109,31 @@ should return the simple help interface.
 ```
 forge <plugin-name> [plugin-arguments]
 ```
+
+---
+
+## Want to contribute to forge?
+
+Fork this repo, then be sure to read our `CONTRIBUTING.md`
+
+To install a specific branch/commit (suppose you've forked this repo, made changes and want to test your work):
+
+```shell
+pipx install git+https://github.com/GIT_USERNAME/forge@YOUR_BRANCH_NAME --force
+pipx install git+https://github.com/GIT_USERNAME/forge@COMMIT_LONG_HASH_HERE --force
+```
+
+This is good way to share your work with others to test changes.
+
+You can also use `pipx` to live edit locally:
+
+- cd to a locally cloned version of forge
+- `pipx install -e . --force`
+
+This will install the local forge repo, any change you make in the repo will be reflected in the next run without having to update or reinstall
+
+To revert back to the mainstream branch you will need to uninstall your local plugin first with either:
+
+`pipx uninstall .`
+
+Then follow the above section's install instructions. (`pipx install tele-forge`)

--- a/forge/cli.py
+++ b/forge/cli.py
@@ -1,7 +1,7 @@
 """ Forge CLI """
 
 from typing import List
-from subprocess import PIPE, Popen
+from subprocess import Popen
 import sys
 import click
 
@@ -100,7 +100,7 @@ def list_forge_plugins() -> None:
 
 def run_forge_plugin(command: List[str]) -> None:
     """ Forge Plugin """
-    process = Popen(command, stdout=PIPE, stderr=PIPE)
+    process = Popen(command)
 
     stdout, stderr = process.communicate()
     if stdout:

--- a/forge/cli.py
+++ b/forge/cli.py
@@ -120,7 +120,7 @@ def bind_plugin_command(plugin_name: str) -> None:
                            allow_extra_args=True
                        ))  # pylint: disable=unused-variable
     def command() -> None:
-        """ Plugin Entrypoint"""
+        """ Plugin Entrypoint """
         args = sys.argv[2:] if len(sys.argv) > 2 else []
         run_forge_plugin([sys.argv[1]] + args)
 

--- a/forge/cli.py
+++ b/forge/cli.py
@@ -1,13 +1,12 @@
 """ Forge CLI """
 
-import sys
-from subprocess import Popen
 from typing import List
-
+from subprocess import Popen
+import sys
 import click
-import pkg_resources
 
 from forge import forge
+import pkg_resources
 
 from .pipx_wrapper import install_to_pipx, uninstall_from_pipx, update_pipx
 

--- a/forge/cli.py
+++ b/forge/cli.py
@@ -4,9 +4,9 @@ from typing import List
 from subprocess import Popen
 import sys
 import click
+import pkg_resources
 
 from forge import forge
-import pkg_resources
 
 from .pipx_wrapper import install_to_pipx, uninstall_from_pipx, update_pipx
 

--- a/forge/cli.py
+++ b/forge/cli.py
@@ -1,9 +1,11 @@
 """ Forge CLI """
 
-from typing import List
-from subprocess import Popen
 import sys
+from subprocess import Popen
+from typing import List
+
 import click
+import pkg_resources
 
 from forge import forge
 
@@ -43,6 +45,7 @@ def print_cmd_help(ctx: click.Context, param, value) -> None:  # type: ignore # 
     callback=print_cmd_help,
     is_flag=True
 )
+@click.version_option(pkg_resources.require("tele-forge")[0].version)
 def forge_cli(help: str) -> None:  # pylint: disable=redefined-builtin, unused-argument
     """ Command Line Interface for Forge """
     if click.get_current_context().invoked_subcommand is None:

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open('requirements.txt') as f:
 
 setup(
     name='tele-forge',
-    version="2.0.0",
+    version="2.0.1",
     description='convenient cli with extendable collection of useful plugins',
     url='https://github.com/TeleTrackingTechnologies/forge',
     author=('Brandon Horn, Kenneth Poling, Paul Verardi, '

--- a/test.ps1
+++ b/test.ps1
@@ -1,11 +1,11 @@
+$ErrorActionPreference = "Stop"
 python -m pip install virtualenv
 virtualenv.exe --always-copy venv
 . venv/Scripts/activate
 pip3 install -r requirements.txt
 pip3 install -r dev-requirements.txt
+pip3 install -e .
 
 python -m pylint -j 4 -r y forge
-if ($LastExitCode) { deactivate; exit $LastExitCode }
 python -m pytest -rf -vvv -x --count 5 --cov=forge --cov-fail-under=80 --cov-report term
-if ($LastExitCode) { deactivate; exit $LastExitCode }
 deactivate


### PR DESCRIPTION
# Forge 2.0.1
- Updated README
   - Plugin install example
   - Forge 1.0 Migration instructions
   - ZSH user notice
   - Fixed Windows environment variable setup instructions
- Removed `PIPE` from `Popen` call
  - Caused issues with swallowing errors in Linux/Mac
- Added `--version` cli option
  - Requested feature